### PR TITLE
Facebook login

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8100/walkthrough",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/angular.json
+++ b/angular.json
@@ -116,8 +116,13 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": ["src/tsconfig.app.json","src/tsconfig.server.json"],
-            "exclude": ["**/node_modules/**"]
+            "tsConfig": [
+              "src/tsconfig.app.json",
+              "src/tsconfig.server.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
           }
         },
         "ionic-cordova-build": {
@@ -195,10 +200,11 @@
           }
         }
       }
-    },
+    }
   },
   "cli": {
-    "defaultCollection": "@ionic/angular-toolkit"
+    "defaultCollection": "@ionic/angular-toolkit",
+    "analytics": "062df84a-83fc-4d03-ae3d-a8a888407b9d"
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {

--- a/facebook-readme.md
+++ b/facebook-readme.md
@@ -17,6 +17,6 @@ From here, we needed to set up a Facebook developer account to register the Sole
 - Relevant Facebook/SoleD app details:
     - App Name: **SoleD**
     - App ID: **117409946941048**
-    - (IOS) Bundle ID / (Android) Google Play Package Name: **com.appblitz.soled**
+    - (iOS) Bundle ID / (Android) Google Play Package Name: **com.appblitz.soled**
     - (Android) Key Hash: **e3RAyD8y4wTO6Nd1JhLGjSxp/bk=**
 

--- a/src/app/categories/categories.page.html
+++ b/src/app/categories/categories.page.html
@@ -5,7 +5,7 @@
         <img src="https://habib.al-mawali.com/wp-content/uploads/IMG_4838-1-768x768.jpg">
       </ion-avatar>
         <ion-label class="greeting">
-          <p>Hey Karl,</p>
+          <p id="UserGreeting">Hey Karl,</p>
           <h3>Buy some more bids!</h3>
         </ion-label>
     </ion-item>

--- a/src/app/categories/categories.page.ts
+++ b/src/app/categories/categories.page.ts
@@ -1,5 +1,10 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
 import { Router } from '@angular/router';
+
+import { isPlatformBrowser } from '@angular/common';
+//import { /*IonSlides, ModalController, MenuController, IonRouterOutlet,*/ isPlatform } from '@ionic/angular';
+
+import { FacebookProviderService } from '../facebook-provider.service';
 
 
 @Component({
@@ -11,12 +16,14 @@ import { Router } from '@angular/router';
     './styles/categories.responsive.scss'
   ]
 })
-export class CategoriesPage { 
+export class CategoriesPage implements AfterViewInit { 
+  user = null;
+
   constructor(
-    public router: Router
-
+    public router: Router,
+    private facebookProvider: FacebookProviderService
   ){}
-
+  
   slideOptions = {
     slidesPerView: 1.5
   };
@@ -29,5 +36,47 @@ export class CategoriesPage {
   launchStorePage(): void {
     console.log('launch store landing page');
     this.router.navigate(['/app/categories/fashion']);
+  }
+
+  // Disable side menu for this page
+  ionViewDidEnter(): void {
+    //this.menu.enable(false);
+  }
+  
+  // Restore to default when leaving this page
+  ionViewDidLeave(): void {
+    //this.menu.enable(true);
+  }
+  
+  ngAfterViewInit(): void {
+    this.user = this.facebookProvider.getUser();
+    let userGreeting = document.getElementById("UserGreeting");
+    if (this.user == null) {
+      userGreeting.innerHTML = "Hi, no one is online. This screen shouldn't be viewable."
+    }
+    else {
+      userGreeting.innerHTML = `Hey ${this.user.name},`
+    }
+
+    // Accessing slides in server platform throw errors
+    // if (isPlatformBrowser(this.platformId)) {
+    //   // ViewChild is set
+    //   this.slides.isBeginning().then(isBeginning => {
+    //     this.isFirstSlide = isBeginning;
+    //   });
+    //   this.slides.isEnd().then(isEnd => {
+    //     this.isLastSlide = isEnd;
+    //   });
+  
+    //   // Subscribe to changes
+    //   this.slides.ionSlideWillChange.subscribe(changes => {
+    //     this.slides.isBeginning().then(isBeginning => {
+    //       this.isFirstSlide = isBeginning;
+    //     });
+    //     this.slides.isEnd().then(isEnd => {
+    //       this.isLastSlide = isEnd;
+    //     });
+    //   });
+    // }
   }
 }

--- a/src/app/facebook-provider.service.spec.ts
+++ b/src/app/facebook-provider.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FacebookProviderService } from './facebook-provider.service';
+
+describe('FacebookProviderService', () => {
+  let service: FacebookProviderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FacebookProviderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/facebook-provider.service.ts
+++ b/src/app/facebook-provider.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@angular/core';
+
+import { FacebookLoginPlugin, FacebookLogin } from '@capacitor-community/facebook-login';
+import { Plugins, registerWebPlugin } from '@capacitor/core';
+import { HttpClient } from '@angular/common/http';
+import { isPlatform } from '@ionic/angular';
+registerWebPlugin(FacebookLogin);
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FacebookProviderService {
+
+  private fbLogin: FacebookLoginPlugin;
+  private user = null;
+  private token = null;
+
+  constructor(
+    private http: HttpClient
+  ) {
+    this.setupFbLogin();
+  }
+
+  // But this one is!
+  private async setupFbLogin() {
+    if (isPlatform('desktop')) {
+      this.fbLogin = FacebookLogin;
+    }
+    else {
+      // Use the native imlementation inside a real app!
+      const { FacebookLogin } = Plugins;
+      this.fbLogin = FacebookLogin;
+    }
+  }
+
+  // And this one too!
+  async FacebookLogin() {
+    console.log("Test 1: FacebookLogin() Starting");
+    const FACEBOOK_PERMISSIONS = ['email', 'user_birthday'];
+    const result = await this.fbLogin.login({ permissions: FACEBOOK_PERMISSIONS });
+    console.log("Test 2: result(from fbLogin.login) != undefined ? (true) ", (result != undefined));
+    if (result.accessToken && result.accessToken.userId) {
+      this.token = result.accessToken;
+      this.loadUserData();
+    }
+    else if (result.accessToken && !result.accessToken.userId) {
+      console.log("Test 3: I'm on the web");
+      // Web only gets the token but not the user ID
+      // Directly call get token to retrieve it now
+      await this.getCurrentToken();
+    }
+    else {
+      // Login failed
+      return false;
+    }
+    console.log("Test 9: Completing login. I don't believe Test 8 will have run yet, so user below is still undefined huh?");
+    console.log('facebook signup, user: ', this.user);
+    //this.router.navigate(['app/categories']);
+    return true;
+  }
+
+  // This one's mine TOO
+  private async getCurrentToken() {
+    console.log("Test 4: getCurrentToken() Starting");
+    const result = await this.fbLogin.getCurrentAccessToken();
+    console.log("Test 5: result(from fbLogin.GetCurrentAccessToken() != undefined ? (true) ", (result != undefined));
+    if (result.accessToken) {
+      this.token = result.accessToken;
+      await this.loadUserData();
+      console.log("Test 7***: this.http.get(url).subscribe(callback) is run outside of this stack I'm guessing")
+    }
+    else {
+      // Not logged in.
+    }
+  }
+
+  // This one's part of Facebook login too.
+  private async loadUserData() {
+    console.log("Test 6: loadUserData() Starting");
+    console.log("Test 7: token = ", this.token);
+    const url = `https://graph.facebook.com/${this.token.userId}?fields=id,name,picture.width(720),birthday,email&access_token=${this.token.token}`;
+    const res = await this.http.get(url).toPromise(); //.then(res => {
+    //console.log("Test 8: Supposed to be setting user. But hmmm, this'll run after 7*** won't it huh?");
+    //console.log('user: ', res);
+    //this.user = res;
+    //});
+    console.log("Test 8***: doing the callback outside of the observable");
+    console.log('user: ', res);
+    this.user = res;
+  }
+
+  // And this one too (for logging out though)
+  async FacebookLogout() {
+    await this.fbLogin.logout();
+    this.user = null;
+    this.token = null;
+  }
+
+  public getUser() {
+    return this.user;
+  }
+}

--- a/src/app/walkthrough/walkthrough.page.html
+++ b/src/app/walkthrough/walkthrough.page.html
@@ -46,10 +46,11 @@
         <h2>LET'S START</h2>
         <p>Save money, win auctions, and buy cool stuff all in one place. Let's get started. </p>
         <div class="login">
-          <ion-button class="facebookButton" color="facebook"  (click)="doGoogleSignup()">Continue With Facebook</ion-button>
+          <ion-button class="facebookButton" color="facebook"  (click)="FacebookLogin()">Continue With Facebook</ion-button>
         </div>
         <div class="legalText">
         <br><br>By creating an account you agree to our <a class="legal-action" (click)="showPrivacyModal()">Privacy Policy</a> and <a class="legal-action" (click)="showTermsModal()">Terms of use</a>.
+        <p id="LoginText"></p>
         </div>
       </div>
     </ion-slide>

--- a/src/app/walkthrough/walkthrough.page.ts
+++ b/src/app/walkthrough/walkthrough.page.ts
@@ -11,7 +11,9 @@ import { FacebookLoginPlugin, FacebookLogin } from '@capacitor-community/faceboo
 import { Plugins, registerWebPlugin } from '@capacitor/core';
 import { HttpClient } from '@angular/common/http';
 //import { isPlatform } from '@ionic/angular'; // Already imoorted above...
-registerWebPlugin(FacebookLogin);
+//registerWebPlugin(FacebookLogin);
+
+import { FacebookProviderService } from '../facebook-provider.service';
 
 @Component({
   selector: 'app-walkthrough',
@@ -32,8 +34,6 @@ export class WalkthroughPage implements AfterViewInit {
   fbLogin: FacebookLoginPlugin;
   user = null;
   token = null;
-  aString = null;//"A string I made";
-  aInt = null;//7;
   
   @ViewChild(IonSlides, { static: true }) slides: IonSlides;
 
@@ -47,9 +47,10 @@ export class WalkthroughPage implements AfterViewInit {
     public modalController: ModalController,
     private routerOutlet: IonRouterOutlet,
     public router: Router,
-    private http: HttpClient
+    private http: HttpClient,
+    private facebookProvider: FacebookProviderService
   ) { 
-    this.setupFbLogin();
+    //this.setupFbLogin();
   }
 
   // Disable side menu for this page
@@ -98,80 +99,90 @@ doGoogleSignup(): void {
   this.router.navigate(['app/categories']);
 }
 
-// But this one is!
-async setupFbLogin() {
-  if (isPlatform('desktop')) {
-    this.fbLogin = FacebookLogin;
-  }
-  else {
-    // Use the native imlementation inside a real app!
-    const { FacebookLogin } = Plugins;
-    this.fbLogin = FacebookLogin;
-  }
-}
+// // But this one is!
+// async setupFbLogin() {
+//   if (isPlatform('desktop')) {
+//     this.fbLogin = FacebookLogin;
+//   }
+//   else {
+//     // Use the native imlementation inside a real app!
+//     const { FacebookLogin } = Plugins;
+//     this.fbLogin = FacebookLogin;
+//   }
+// }
 
 // And this one too!
 async FacebookLogin() {
-  console.log("Test 1: FacebookLogin() Starting");
-  const FACEBOOK_PERMISSIONS = ['email', 'user_birthday'];
-  const result = await this.fbLogin.login({ permissions: FACEBOOK_PERMISSIONS });
-  console.log("Test 2: result(from fbLogin.login) != undefined ? (true) ", (result != undefined));
-  if (result.accessToken && result.accessToken.userId) {
-    this.token = result.accessToken;
-    this.loadUserData(); 
+  var loginText = document.getElementById("LoginText");
+  const res = await this.facebookProvider.FacebookLogin();
+  if (res) {
+    const user = this.facebookProvider.getUser();
+    loginText.innerHTML = `Hi ${user.name}`;
+    this.router.navigate(['app/categories']);
   }
-  else if (result.accessToken && !result.accessToken.userId) {
-    console.log("Test 3: I'm on the web");
-    // Web only gets the token but not the user ID
-    // Directly call get token to retrieve it now
-    await this.getCurrentToken(); 
+  else { 
+    loginText.innerHTML = "Failed to Login, please try again"
   }
-  else {
-    // Login failed
-    return
-  }
-  console.log("Test 9: Completing login. I don't believe Test 8 will have run yet, so user below is still undefined huh?");
-  console.log('facebook signup, user: ', this.user);
-  //this.router.navigate(['app/categories']);
-  document.getElementById("LoginText").innerHTML = `Hi ${this.user.name}`;
+  // console.log("Test 1: FacebookLogin() Starting");
+  // const FACEBOOK_PERMISSIONS = ['email', 'user_birthday'];
+  // const result = await this.fbLogin.login({ permissions: FACEBOOK_PERMISSIONS });
+  // console.log("Test 2: result(from fbLogin.login) != undefined ? (true) ", (result != undefined));
+  // if (result.accessToken && result.accessToken.userId) {
+  //   this.token = result.accessToken;
+  //   this.loadUserData(); 
+  // }
+  // else if (result.accessToken && !result.accessToken.userId) {
+  //   console.log("Test 3: I'm on the web");
+  //   // Web only gets the token but not the user ID
+  //   // Directly call get token to retrieve it now
+  //   await this.getCurrentToken(); 
+  // }
+  // else {
+  //   // Login failed
+  //   return
+  // }
+  // console.log("Test 9: Completing login. I don't believe Test 8 will have run yet, so user below is still undefined huh?");
+  // console.log('facebook signup, user: ', this.user);
+  // //this.router.navigate(['app/categories']);
+  // document.getElementById("LoginText").innerHTML = `Hi ${this.user.name}`;
 }
 
-// This one's mine TOO
-async getCurrentToken() {
-  console.log("Test 4: getCurrentToken() Starting");
-  const result = await this.fbLogin.getCurrentAccessToken();
-  console.log("Test 5: result(from fbLogin.GetCurrentAccessToken() != undefined ? (true) ", (result != undefined));
-  if (result.accessToken) {
-    this.token = result.accessToken;
-    await this.loadUserData(); 
-    console.log("Test 7***: this.http.get(url).subscribe(callback) is run outside of this stack I'm guessing")
-  }
-  else {
-    // Not logged in.
-  }
-}
+// // This one's mine TOO
+// async getCurrentToken() {
+//   console.log("Test 4: getCurrentToken() Starting");
+//   const result = await this.fbLogin.getCurrentAccessToken();
+//   console.log("Test 5: result(from fbLogin.GetCurrentAccessToken() != undefined ? (true) ", (result != undefined));
+//   if (result.accessToken) {
+//     this.token = result.accessToken;
+//     await this.loadUserData(); 
+//     console.log("Test 7***: this.http.get(url).subscribe(callback) is run outside of this stack I'm guessing")
+//   }
+//   else {
+//     // Not logged in.
+//   }
+// }
 
-// This one's part of Facebook login too.
-async loadUserData() {
-  console.log("Test 6: loadUserData() Starting");
-  console.log("Test 7: token = ", this.token);
-  const url = `https://graph.facebook.com/${this.token.userId}?fields=id,name,picture.width(720),birthday,email&access_token=${this.token.token}`;
-  const res = await this.http.get(url).toPromise(); //.then(res => {
-    //console.log("Test 8: Supposed to be setting user. But hmmm, this'll run after 7*** won't it huh?");
-    //console.log('user: ', res);
-    //this.user = res;
-  //});
-  console.log("Test 8***: doing the callback outside of the observable");
-  console.log('user: ', res);
-  this.user = res;
-}
+// // This one's part of Facebook login too.
+// async loadUserData() {
+//   console.log("Test 6: loadUserData() Starting");
+//   console.log("Test 7: token = ", this.token);
+//   const url = `https://graph.facebook.com/${this.token.userId}?fields=id,name,picture.width(720),birthday,email&access_token=${this.token.token}`;
+//   const res = await this.http.get(url).toPromise(); //.then(res => {
+//     //console.log("Test 8: Supposed to be setting user. But hmmm, this'll run after 7*** won't it huh?");
+//     //console.log('user: ', res);
+//     //this.user = res;
+//   //});
+//   console.log("Test 8***: doing the callback outside of the observable");
+//   console.log('user: ', res);
+//   this.user = res;
+// }
 
-// And this one too (for logging out though)
-async FacebookLogout() {
-  await this.fbLogin.logout();
-  this.user = null;
-  this.token = null;
-}
+// // And this one too (for logging out though)
+// async FacebookLogout() {
+//   await this.fbLogin.logout();
+//   this.user = null;
+//   this.token = null;
+// }
 
   async showTermsModal() {
     const modal = await this.modalController.create({

--- a/src/app/walkthrough/walkthrough.page.ts
+++ b/src/app/walkthrough/walkthrough.page.ts
@@ -112,42 +112,39 @@ async setupFbLogin() {
 
 // And this one too!
 async FacebookLogin() {
+  console.log("Test 1: FacebookLogin() Starting");
   const FACEBOOK_PERMISSIONS = ['email', 'user_birthday'];
   const result = await this.fbLogin.login({ permissions: FACEBOOK_PERMISSIONS });
-  // console.log('result: ', result);
-  // console.log('aString: ',this.aString);
-  // console.log('aInt: ',this.aInt);
-  // this.aString = "Some text";
-  // this.aInt = 7;
-  // console.log('testing change in the same page');
-  // console.log('aString: ',this.aString);
-  // console.log('aInt: ',this.aInt);
+  console.log("Test 2: result(from fbLogin.login) != undefined ? (true) ", (result != undefined));
   if (result.accessToken && result.accessToken.userId) {
     this.token = result.accessToken;
-    await this.loadUserData(); ///////////
+    this.loadUserData(); 
   }
   else if (result.accessToken && !result.accessToken.userId) {
+    console.log("Test 3: I'm on the web");
     // Web only gets the token but not the user ID
     // Directly call get token to retrieve it now
-    await this.getCurrentToken(); ////////
+    await this.getCurrentToken(); 
   }
   else {
     // Login failed
     return
   }
-
+  console.log("Test 9: Completing login. I don't believe Test 8 will have run yet, so user below is still undefined huh?");
   console.log('facebook signup, user: ', this.user);
-  // this.router.navigate(['app/categories'], navigationExtras);
-  //document.getElementById("LoginText").innerHTML = this.user.name;
+  //this.router.navigate(['app/categories']);
+  document.getElementById("LoginText").innerHTML = `Hi ${this.user.name}`;
 }
 
 // This one's mine TOO
 async getCurrentToken() {
+  console.log("Test 4: getCurrentToken() Starting");
   const result = await this.fbLogin.getCurrentAccessToken();
-
+  console.log("Test 5: result(from fbLogin.GetCurrentAccessToken() != undefined ? (true) ", (result != undefined));
   if (result.accessToken) {
     this.token = result.accessToken;
-    await this.loadUserData(); ///////////////////////////////
+    await this.loadUserData(); 
+    console.log("Test 7***: this.http.get(url).subscribe(callback) is run outside of this stack I'm guessing")
   }
   else {
     // Not logged in.
@@ -156,11 +153,17 @@ async getCurrentToken() {
 
 // This one's part of Facebook login too.
 async loadUserData() {
+  console.log("Test 6: loadUserData() Starting");
+  console.log("Test 7: token = ", this.token);
   const url = `https://graph.facebook.com/${this.token.userId}?fields=id,name,picture.width(720),birthday,email&access_token=${this.token.token}`;
-  this.http.get(url).subscribe(res => {
+  const res = await this.http.get(url).toPromise(); //.then(res => {
+    //console.log("Test 8: Supposed to be setting user. But hmmm, this'll run after 7*** won't it huh?");
     //console.log('user: ', res);
-    this.user = res;
-  });
+    //this.user = res;
+  //});
+  console.log("Test 8***: doing the callback outside of the observable");
+  console.log('user: ', res);
+  this.user = res;
 }
 
 // And this one too (for logging out though)
@@ -169,14 +172,6 @@ async FacebookLogout() {
   this.user = null;
   this.token = null;
 }
-
-  // let navigationExtras: NavigationExtras = {
-  //   state: {
-  //     user: this.user,
-  //     tString: this.aString,
-  //     tInt: this.aInt
-  //   }
-  // };
 
   async showTermsModal() {
     const modal = await this.modalController.create({

--- a/src/index.html
+++ b/src/index.html
@@ -108,4 +108,23 @@
   </noscript>
   <app-root></app-root>
 </body>
+<script>
+  window.fbAsyncInit = function () {
+    FB.init({
+      appId: '117409946941048',
+      cookie: true, // enable cookies to allow the server to access the session
+      xfbml: true, // parse social plugins on this page
+      version: 'v5.0' // use graph api current version
+    });
+  };
+
+  // Load the SDK asynchronously
+  (function (d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = "https://connect.facebook.net/en_US/sdk.js";
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));
+</script>
 </html>


### PR DESCRIPTION
Added the initial Facebook login functionality that allows users to login to their account from the walkthrough page and extends that data to the rest of the app through a service (facebook-provider-service) that can be called on from any page that injects it.

The Facebook login needs to be stored statically when the app closes and re-loaded on re-opening so users don't have to log in again.

Also need to implement logout functionality and data deletion to complete Facebook's API regulation.